### PR TITLE
Compatibility with v1.xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,8 @@ Note: You need to know the IP and password of you device. The password is writte
 # Working firmware versions
 * v2.02
 * v2.22
- 
+
+## Partial support
+* v1.24 (State changing working, but fails to read temperature or current consumption)
+
 If you have it working on other firmware versions please let me know.

--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -22,7 +22,7 @@ class SmartPlug(object):
     # query and print current state of plug
     print(p.state)
 
-    Note: 
+    Note:
     The library is greatly inspired by the javascript library by @bikerp (https://github.com/bikerp).
     Class layout is inspired by @rkabadi (https://github.com/rkabadi) for the Edimax Smart plug.
     """
@@ -53,7 +53,7 @@ class SmartPlug(object):
 
     def controlParameters(self, module, status):
         """Returns control parameters as XML.
-        
+
         :type module: str
         :type status: str
         :param module: The module number/ID
@@ -65,7 +65,7 @@ class SmartPlug(object):
 
     def radioParameters(self, radio):
         """Returns RadioID as XML.
-        
+
         :type radio: str
         :param radio: Radio number/ID
         """
@@ -118,7 +118,7 @@ class SmartPlug(object):
         headers = {'Content-Type' : '"text/xml; charset=utf-8"',
                    'SOAPAction': '"http://purenetworks.com/HNAP1/{}"'.format(Action),
                    'HNAP_AUTH' : '{}'.format(AUTHKey),
-                   'Cookie' : '"uid={}"'.format(auth[1])}
+                   'Cookie' : 'uid={}'.format(auth[1])}
 
         try:
             response = urlopen(Request(self.url, payload.encode(), headers))
@@ -152,7 +152,7 @@ class SmartPlug(object):
             float(res)
         except ValueError:
             _LOGGER.error("Failed to retrieve current power consumption from SmartPlug")
-        
+
         return res
     @property
     def total_consumption(self):
@@ -210,7 +210,7 @@ class SmartPlug(object):
         of a publickey, a challenge string and a cookie.
         These values are then hashed by a MD5 algorithm producing a privatekey
         used for the header and a hashed password for the XML payload.
-        
+
         If everything is accepted the XML returned will contain a LoginResult tag with the
         string 'success'.
 
@@ -253,7 +253,7 @@ class SmartPlug(object):
         headers = {'Content-Type' : '"text/xml; charset=utf-8"',
            'SOAPAction': '"http://purenetworks.com/HNAP1/Login"',
            'HNAP_AUTH' : '"{}"'.format(PrivateKey),
-           'Cookie' : '"uid={}"'.format(Cookie)}
+           'Cookie' : 'uid={}'.format(Cookie)}
         response = urlopen(Request(self.url, response_payload, headers))
         xmlData = response.read().decode()
         root = ET.fromstring(xmlData)
@@ -284,7 +284,7 @@ class SmartPlug(object):
         </soap:Body>
         </soap:Envelope>
         '''
-    
+
     def auth_payload(self, login_pwd):
         """Generate a new payload containing generated hash information.
 

--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -61,7 +61,7 @@ class SmartPlug(object):
         :return XML string to join with payload
         """
         return '''{}<NickName>Socket 1</NickName><Description>Socket 1</Description>
-                  <OPStatus>{}</OPStatus>'''.format(self.moduleParameters(module), status)
+                  <OPStatus>{}</OPStatus><Controller>1</Controller>'''.format(self.moduleParameters(module), status)
 
     def radioParameters(self, radio):
         """Returns RadioID as XML.


### PR DESCRIPTION
Hi again. 

Firstly I'd like to say that I've been in contact with D-Link Australia and have obtained and flashed a firmware that identifies itself as V1.24B01Beta. There doesn't seem to be a difference between this and v1.24.

After comparing pyW215 to dsp-w215-hnap (which works, surprisingly), I found a few differences in the way dsp-w215-hnap authenticated and sent state change requests. After fixing these few differences, I have managed to get pyW215 working with my v1.24 plug.

Here's a list of what I managed to get working;
### Working
- Authentication
- `state`
- `state=`
### Not working
- `temperature` (returns 0 every time)
- `current_consumption` (returns 0 every time)
- `total_consumption` (logs warning `Could not find TotalConsumption in response.`, possibly unsupported?)

I'd recommend you test this patch with your 2.xx plug to ensure I haven't broken anything. I may try and work on `temperature` and `current_consumption` in the future, but that would most likely require me to decompile or reverse-engineer the phone app, as the `dsp-w215-hnap` implementation doesn't work there either.
