### PR TITLE
Return N/A for TotalConsumption on legacy protocol

### DIFF
--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -171,6 +171,11 @@ class SmartPlug(object):
     @property
     def total_consumption(self):
         """Get the total power consumpuntion in the device lifetime."""
+        if self.use_legacy_protocol:
+            # TotalConsumption currently fails on the legacy protocol and
+            # creates a mess in the logs. Just return 'N/A' for now.
+            return 'N/A'
+
         res = 'N/A'
         try:
             res = self.SOAPAction("GetPMWarningThreshold", "TotalConsumption", self.moduleParameters("2"))


### PR DESCRIPTION
Hi again,

I've noticed in my Home Assistant logs that pyW215 keeps attempting to access the TotalConsumption from my plug, but that currently isn't working on the legacy protocol. Home Assistant seems to update this twice a minute which leads to a lot of mess in the logs. 

```
16-10-25 16:08:02 pyW215.pyW215: Could not find TotalConsumption in response.
16-10-25 16:08:32 pyW215.pyW215: Could not find TotalConsumption in response.
16-10-25 16:09:02 pyW215.pyW215: Could not find TotalConsumption in response.
16-10-25 16:09:32 pyW215.pyW215: Could not find TotalConsumption in response.
```

I've patched it over for now so `total_consumption` simply returns `N/A` if `use_legacy_protocol` is set to True. If someone has managed to get current consumption reading working on the legacy firmware, please remove this check.
