### PR TITLE
Consumption through my_cgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library is largely inspired by the javascript implementation by @bikerp [dsp
 from pyW215 import SmartPlug
 
 sp = SmartPlug('192.168.1.110', '******')
- 
+
 # Get values if available otherwise return N/A
 print(sp.current_consumption)
 print(sp.temperature)
@@ -29,7 +29,7 @@ Note: You need to know the IP and password of you device. The password is writte
 Note: If you experience problems with the switch first try upgrading to the latest supported firmware through the D-Link app. If the problem persists feel free to open an issue about the problem.
 
 ## Partial support
-* v1.24 (State changing working, but no support for reading temperature or current consumption)
+* v1.24 (State changing and current consumption working, but no support for reading temperature)
 * D-Link W110 smart switch (only state changing is supported)
 
 If you have it working on other firmware or hardware versions please let me know.

--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -155,6 +155,7 @@ class SmartPlug(object):
         return value
 
     def fetchMyCgi(self):
+        """Fetches statistics from my_cgi.cgi"""
         try:
             response = urlopen(Request('http://{}/my_cgi.cgi'.format(self.ip), b'request=create_chklst'));
         except (HTTPError, URLError):

--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -154,14 +154,32 @@ class SmartPlug(object):
         self._error_report = False
         return value
 
+    def fetchMyCgi(self):
+        try:
+            response = urlopen(Request('http://{}/my_cgi.cgi'.format(self.ip), b'request=create_chklst'));
+        except (HTTPError, URLError):
+            _LOGGER.warning("Failed to open url to {}".format(self.ip))
+            self._error_report = True
+            return None
+
+        lines = response.readlines()
+        return {line.decode().split(':')[0].strip(): line.decode().split(':')[1].strip() for line in lines}
+
     @property
     def current_consumption(self):
         """Get the current power consumption in Watt."""
         res = 'N/A'
-        try:
-            res = self.SOAPAction('GetCurrentPowerConsumption', 'CurrentConsumption', self.moduleParameters("2"))
-        except:
-            return 'N/A'
+        if self.use_legacy_protocol:
+            # Use /my_cgi.cgi to retrieve current consumption
+            try:
+                res = self.fetchMyCgi()['Meter Watt']
+            except:
+                return 'N/A'
+        else:
+            try:
+                res = self.SOAPAction('GetCurrentPowerConsumption', 'CurrentConsumption', self.moduleParameters("2"))
+            except:
+                return 'N/A'
 
         if res is None:
             return 'N/A'


### PR DESCRIPTION
The /my_cgi.cgi endpoint can be used on v1.xx to retrieve the current power consumption in Watts. This PR adds the ability to retrieve it when the legacy protocol is enabled.