### PR TITLE
Python 2.x support

### DIFF
--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -1,6 +1,11 @@
 
-from urllib.request import Request, urlopen
-from urllib.error import URLError, HTTPError
+try:
+    from urllib.request import Request, urlopen
+    from urllib.error import URLError, HTTPError
+except ImportError:
+    # Assume Python 2.x
+    from urllib2 import Request, urlopen
+    from urllib2 import URLError, HTTPError
 import xml.etree.ElementTree as ET
 import hmac
 import time


### PR DESCRIPTION
Resolve issue #11
Add try/except for Python 3 libraries first.
Alternative is to check python version, try/except technique is more Pythonic.

Works for turning on/off my DSP-W110.