### PR TITLE
Blank SOAP Action string fails on hardware A1 v1.14

### DIFF
--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -57,7 +57,7 @@ class SmartPlug(object):
         if self.use_legacy_protocol:
             _LOGGER.info("Enabled support for legacy firmware.")
         self._error_report = False
-        self.model_name = self.SOAPAction(Action="", responseElement="ModelName", params = "")
+        self.model_name = self.SOAPAction(Action="GetDeviceSettings", responseElement="ModelName", params = "")
 
     def moduleParameters(self, module):
         """Returns moduleID XML.


### PR DESCRIPTION
I get this error when calling init on my hardware:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/scott/src/pyW215/pyW215/pyW215.py", line 60, in __init__
    self.model_name = self.SOAPAction(Action="", responseElement="ModelName", params = "")
  File "/home/scott/src/pyW215/pyW215/pyW215.py", line 152, in SOAPAction
    root = ET.fromstring(xmlData)
  File "/usr/lib/python3.5/xml/etree/ElementTree.py", line 1344, in XML
    parser.feed(text)
xml.etree.ElementTree.ParseError: syntax error: line 1, column 0
```
This pull request fixes the issue for me.