### PR TITLE
Allow re-authentication if authentication failed

### DIFF
--- a/pyW215/pyW215.py
+++ b/pyW215/pyW215.py
@@ -341,9 +341,6 @@ class SmartPlug(object):
             self._error_report = True
             return None
 
-        if self._error_report is True:
-            return None
-
         Challenge = ChallengeResponse.text
         Cookie = CookieResponse.text
         Publickey = PublickeyResponse.text


### PR DESCRIPTION
This change reverts broken logic that prevented re-authentication when `self._error_report` is true. I dont think `self._error_report` is meant to be for control flow beyond limiting error reporting. 

This problem was initially reported in this [comment]( https://github.com/LinuxChristian/pyW215/commit/6378ede004040548a416be144c0874b40f2f2d39#commitcomment-46084407)

This change allows home-assistant to successfully reconnect to the W215 after losing connection
